### PR TITLE
fix: nativeName fix for Montenegrin language as per iso639_2

### DIFF
--- a/data/advanced.json
+++ b/data/advanced.json
@@ -10620,7 +10620,7 @@
     "639-2B": "cnr",
     "639-2T": "cnr",
     "639-1": null,
-    "nativeName": "srpski (Crna Gora)",
+    "nativeName": "crnogorski / црногорски",
     "englishName": "Montenegrin"
   },
   {


### PR DESCRIPTION
As per https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes, for `Montenegrin `language with code `'cnr'` the nativeName should be `crnogorski / црногорски`. 